### PR TITLE
Compatibility with Crafting Quality Rebalanced

### DIFF
--- a/1.3/Source/VanillaTraitsExpanded/HarmonyPatches/GenerateQualityCreatedByPawn_Patch.cs
+++ b/1.3/Source/VanillaTraitsExpanded/HarmonyPatches/GenerateQualityCreatedByPawn_Patch.cs
@@ -42,22 +42,23 @@ namespace VanillaTraitsExpanded
                 {
 					var newResult = (QualityCategory)((int)__result + 1);
 					__result = newResult;
+					
+					if (__result == QualityCategory.Legendary && !__state)
+					{
+						if (ModsConfig.IdeologyActive)
+						{
+							var role = pawn.Ideo.GetRole(pawn);
+							if (role != null && role.def.defName == "IdeoRole_ProductionSpecialist")
+							{
+								return; // we allow legendary for production specialist
+							}
+						}
+						__result = QualityCategory.Masterwork;
+					}
 				}
 				if (__result == QualityCategory.Normal || __result == QualityCategory.Awful || __result == QualityCategory.Poor)
 				{
 					pawn.TryGiveThought(VTEDefOf.VTE_CreatedLowQualityItem);
-				}
-				if (__result == QualityCategory.Legendary && !__state)
-                {
-					if (ModsConfig.IdeologyActive)
-                    {
-						var role = pawn.Ideo.GetRole(pawn);
-						if (role != null && role.def.defName == "IdeoRole_ProductionSpecialist")
-                        {
-							return; // we allow legendary for production specialist
-                        }
-                    }
-					__result = QualityCategory.Masterwork;
 				}
 			}
 		}


### PR DESCRIPTION
Only block legendary items that were made legendary by the Perfectionist trait, so other mods can create Legendary items